### PR TITLE
Add support for more than 2 bytes hexadecimals

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -546,7 +546,6 @@ func TestUnicodeSupplementaryCharInRange(t *testing.T) {
 
 func TestHexadecimalCurlyBraces(t *testing.T) {
 	re := MustCompile(`\x20`, 0)
-
 	if m, err := re.MatchString(" "); err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	} else if !m {
@@ -593,6 +592,34 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 		t.Fatalf("Unexpected err: %v", err)
 	} else if !m {
 		t.Fatalf("Expected match")
+	}
+
+	if _, err := Compile(`\x2R`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x0`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{2`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{2R`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{2R}`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{}`, 0); err == nil {
+		t.Fatalf("Expected error")
+	}
+	_, err := Compile(`\x{10000}`, 0);	if err == nil {
+		t.Fatal("Expected error")
 	}
 }
 /*

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -600,6 +600,12 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 	if _, err := Compile(`\x0`, 0); err == nil {
 		t.Fatal("Expected error")
 	}
+	if _, err := Compile(`\x000`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x00000`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
 	if _, err := Compile(`\x`, 0); err == nil {
 		t.Fatal("Expected error")
 	}
@@ -618,7 +624,10 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 	if _, err := Compile(`\x{}`, 0); err == nil {
 		t.Fatalf("Expected error")
 	}
-	_, err := Compile(`\x{10000}`, 0);	if err == nil {
+	if _, err := Compile(`\x{10000}`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
+	if _, err := Compile(`\x{10000`, 0); err == nil {
 		t.Fatal("Expected error")
 	}
 }

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -630,6 +630,9 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 	if _, err := Compile(`\x{10000`, 0); err == nil {
 		t.Fatal("Expected error")
 	}
+	if _, err := Compile(`\x{1234`, 0); err == nil {
+		t.Fatal("Expected error")
+	}
 }
 /*
 func TestPcreStuff(t *testing.T) {

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -544,6 +544,57 @@ func TestUnicodeSupplementaryCharInRange(t *testing.T) {
 	}
 }
 
+func TestHexadecimalCurlyBraces(t *testing.T) {
+	re := MustCompile(`\x20`, 0)
+
+	if m, err := re.MatchString(" "); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{C4}`, 0)
+	if m, err := re.MatchString("Ä"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{0C5}`, 0)
+	if m, err := re.MatchString("Å"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{00C6}`, 0)
+	if m, err := re.MatchString("Æ"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{1FF}`, 0)
+	if m, err := re.MatchString("ǿ"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{02FF}`, 0)
+	if m, err := re.MatchString("˿"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+
+	re = MustCompile(`\x{1392}`, 0)
+	if m, err := re.MatchString("᎒"); err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	} else if !m {
+		t.Fatalf("Expected match")
+	}
+}
 /*
 func TestPcreStuff(t *testing.T) {
 	re := MustCompile(`(?(?=(a))a)`, Debug)

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -600,12 +600,6 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 	if _, err := Compile(`\x0`, 0); err == nil {
 		t.Fatal("Expected error")
 	}
-	if _, err := Compile(`\x000`, 0); err == nil {
-		t.Fatal("Expected error")
-	}
-	if _, err := Compile(`\x00000`, 0); err == nil {
-		t.Fatal("Expected error")
-	}
 	if _, err := Compile(`\x`, 0); err == nil {
 		t.Fatal("Expected error")
 	}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1644,11 +1644,17 @@ func (p *parser) scanControl() (rune, error) {
 func (p *parser) scanHex(c int, wantClosingBrace bool) (rune, error) {
 	i := -1
 
-	charsRight := p.charsRight()
-	if !wantClosingBrace && charsRight < c {
-		return 0, p.getErr(ErrTooFewHex)
-	} else if (!wantClosingBrace && charsRight > c) || (wantClosingBrace && charsRight > c + 1) {
-		return 0, p.getErr(ErrTooManyHex)
+	var charsRight int
+	if wantClosingBrace {
+		charsRight = p.charsRight()
+		if charsRight > c + 1 {
+			return 0, p.getErr(ErrTooManyHex)
+		}
+	} else {
+		charsRight = c
+		if p.charsRight() < charsRight {
+			return 0, p.getErr(ErrTooFewHex)
+		}
 	}
 
 	var ch rune


### PR DESCRIPTION
This commit adds support for more than 2 bytes hexadecimal numbers by using the curly braces format \x{FFFF} as used by Perl and PCRE.