### PR TITLE
Fixed decimal escape handling in ECMAScript mode.

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -717,6 +717,27 @@ func TestECMAOctal(t *testing.T) {
 	} else if !m {
 		t.Fatal("Expected match")
 	}
+
+	if m, err := re.MatchString("x"); err != nil {
+		t.Fatal(err)
+	} else if m {
+		t.Fatal("Expected no match")
+	}
+
+	re = MustCompile(`\377`, ECMAScript)
+	if m, err := re.MatchString("\u00ff"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+
+	re = MustCompile(`\400`, ECMAScript)
+	if m, err := re.MatchString(" 0"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+
 }
 
 func TestNegateRange(t *testing.T) {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1250,10 +1250,10 @@ func (p *parser) scanBasicBackslash(scanOnly bool) (*regexNode, error) {
 			return nil, nil
 		}
 
-		if p.useOptionE() || p.isCaptureSlot(capnum) {
+		if p.isCaptureSlot(capnum) {
 			return newRegexNodeM(ntRef, p.options, capnum), nil
 		}
-		if capnum <= 9 {
+		if capnum <= 9 && !p.useOptionE() {
 			return nil, p.getErr(ErrUndefinedBackRef, capnum)
 		}
 
@@ -1808,11 +1808,11 @@ func (p *parser) scanOctal() rune {
 	i := 0
 	d := int(p.rightChar(0) - '0')
 	for c > 0 && d <= 7 {
-		i *= 8
-		i += d
-		if p.useOptionE() && i >= 0x20 {
+		if i >= 0x20 && p.useOptionE() {
 			break
 		}
+		i *= 8
+		i += d
 		c--
 
 		p.moveRight(1)


### PR DESCRIPTION
In ECMAScript decimal escape sequences should be treated as a reference to a capture group but only if such group exists. If it does not, it should be treated as a character code.

The last part was broken, this PR fixes that. Please consider merging.
