### PR TITLE
Fix start at end

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -239,13 +239,7 @@ func (re *Regexp) getRunesAndStart(s string, startAt int) ([]rune, int) {
 }
 
 func getRunes(s string) []rune {
-	ret := make([]rune, len(s))
-	i := 0
-	for _, r := range s {
-		ret[i] = r
-		i++
-	}
-	return ret[:i]
+	return []rune(s)
 }
 
 // MatchRunes return true if the runes matches the regex

--- a/regexp.go
+++ b/regexp.go
@@ -235,6 +235,9 @@ func (re *Regexp) getRunesAndStart(s string, startAt int) ([]rune, int) {
 		ret[i] = r
 		i++
 	}
+	if startAt == len(s) {
+		runeIdx = i
+	}
 	return ret[:i], runeIdx
 }
 

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -877,6 +877,17 @@ func TestAlternationConstruct_Matches(t *testing.T) {
 	}
 }
 
+func TestStartAtEnd(t *testing.T) {
+	re := MustCompile("(?:)", 0)
+	m, err := re.FindStringMatchStartingAt("t", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil {
+		t.Fatal("Expected match")
+	}
+}
+
 func TestParserFuzzCrashes(t *testing.T) {
 	var crashes = []string{
 		"(?'-", "(\\c0)", "(\\00(?())", "[\\p{0}", "(\x00?.*.()?(()?)?)*.x\xcb?&(\\s\x80)", "\\p{0}", "[0-[\\p{0}",


### PR DESCRIPTION
Search starting at the UTF-8 string's length was failing because it was unable to find the matching offset in the UTF-8 string. This PR fixes the problem. Also, changed converting from a UTF-8 string to an array of runes by simply doing `[]rune(s)`. Please consider merging.