### PR TITLE
Go 1.15: Convert int to string using rune()

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -605,7 +605,7 @@ func TestHexadecimalCurlyBraces(t *testing.T) {
 	}
 
 	re = MustCompile(`\x{0010ffff}`, 0)
-	if m, err := re.MatchString(string(0x10ffff)); err != nil {
+	if m, err := re.MatchString(string(rune(0x10ffff))); err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	} else if !m {
 		t.Fatalf("Expected match")


### PR DESCRIPTION
See https://github.com/golang/go/issues/32479

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>