### PR TITLE
Fix handling of numeric backslash escape sequences in ECMAScript mode

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -777,6 +777,21 @@ func TestECMAInvalidEscapeCharClass(t *testing.T) {
 	}
 }
 
+func TestECMAScriptXCurlyBraceEscape(t *testing.T) {
+	re := MustCompile(`\x{20}`, ECMAScript)
+	if m, err := re.MatchString(" "); err != nil {
+		t.Fatal(err)
+	} else if m {
+		t.Fatal("Expected no match")
+	}
+
+	if m, err := re.MatchString("xxxxxxxxxxxxxxxxxxxx"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+}
+
 func TestNegateRange(t *testing.T) {
 	re := MustCompile(`[\D]`, 0)
 	if m, err := re.MatchString("A"); err != nil {

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -740,6 +740,43 @@ func TestECMAOctal(t *testing.T) {
 
 }
 
+func TestECMAInvalidEscape(t *testing.T) {
+	re := MustCompile(`\x0`, ECMAScript)
+	if m, err := re.MatchString("x0"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+
+	re = MustCompile(`\x0z`, ECMAScript)
+	if m, err := re.MatchString("x0z"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+}
+
+func TestECMAInvalidEscapeCharClass(t *testing.T) {
+	re := MustCompile(`[\x0]`, ECMAScript)
+	if m, err := re.MatchString("x"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+
+	if m, err := re.MatchString("0"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("Expected match")
+	}
+
+	if m, err := re.MatchString("z"); err != nil {
+		t.Fatal(err)
+	} else if m {
+		t.Fatal("Expected no match")
+	}
+}
+
 func TestNegateRange(t *testing.T) {
 	re := MustCompile(`[\D]`, 0)
 	if m, err := re.MatchString("A"); err != nil {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1663,8 +1663,11 @@ func (p *parser) scanCharEscape() (r rune, err error) {
 	case 'x':
 		// support for \x{HEX} syntax from Perl and PCRE
 		if p.charsRight() > 0 && p.rightChar(0) == '{' {
+			if p.useOptionE() {
+				return ch, nil
+			}
 			p.moveRight(1)
-			r, err = p.scanHexUntilBrace()
+			return p.scanHexUntilBrace()
 		} else {
 			r, err = p.scanHex(2)
 		}


### PR DESCRIPTION
In ECMAScript incomplete numeric escape sequences do not cause syntax errors, instead they are treated like an escaped character (which is then unescaped) followed by number(s), so `/\x0/` for example is equivalent to `/x0/`.

Also, there is no support for \x{..} notation.

This PR fixes both issues.