### PR TITLE
Add support for Perl(PCRE) named and unnamed group capturing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The internals of `regexp2` always operate on `[]rune` so `Index` and `Length` da
 | named back reference `\k'name'` | no | yes |
 | named ascii character class `[[:foo:]]`| yes | no (yes in RE2 compat mode) |
 | conditionals `(?(expr)yes\|no)` | no | yes |
+| PCRE capture group order | no | no (yes in MaintainCaptureOrder mode) |
 
 ## RE2 compatibility mode
 The default behavior of `regexp2` is to match the .NET regexp engine, however the `RE2` option is provided to change the parsing to increase compatibility with RE2.  Using the `RE2` option when compiling a regexp will not take away any features, but will change the following behaviors:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ if isMatch, _ := re.MatchString(`Something to match`); isMatch {
 
 This feature is a work in progress and I'm open to ideas for more things to put here (maybe more relaxed character escaping rules?).
 
+## MaintainCaptureOrder mode
+The default behavior of `regexp2` is to match the .NET regexp engine, which unlike PCRE, doesn't maintain the order of the captures and appends the named capture groups to the end of captured groups. Using the `MaintainCaptureOrder` option when compiling a regexp will keep the order of named and unnamed capture groups.
+
+```go
+re := regexp2.MustCompile(`(?<first>This) (is) a (?<last>test)`, regexp2.RE2)
+if match, _ := re.FindStringMatch(`This is a test`); match != nil {
+    // match.Groups()[1].String() == "This"
+    // match.Groups()[1].Name == "first"
+    // match.Groups()[2].String() == "is"
+    // match.Groups()[2].Name == "2"
+    // match.Groups()[3].String() == "test"
+    // match.Groups()[3].Name == "last"
+}
+```
 
 ## Library features that I'm still working on
 - Regex split

--- a/regexp.go
+++ b/regexp.go
@@ -121,7 +121,7 @@ const (
 	Debug                                = 0x0080 // "d"
 	ECMAScript                           = 0x0100 // "e"
 	RE2                                  = 0x0200 // RE2 (regexp package) compatibility mode
-	MaintainCaptureOrder                 = 0x1000 // Maintain named and unnamed capture order
+	MaintainCaptureOrder                 = 0x0400 // Maintain named and unnamed capture order
 )
 
 func (re *Regexp) RightToLeft() bool {

--- a/regexp.go
+++ b/regexp.go
@@ -121,6 +121,7 @@ const (
 	Debug                                = 0x0080 // "d"
 	ECMAScript                           = 0x0100 // "e"
 	RE2                                  = 0x0200 // RE2 (regexp package) compatibility mode
+	MaintainCaptureOrder                 = 0x1000 // Maintain named and unnamed capture order
 )
 
 func (re *Regexp) RightToLeft() bool {

--- a/regexp_MaintainCaptureOrder_test.go
+++ b/regexp_MaintainCaptureOrder_test.go
@@ -106,7 +106,6 @@ func TestMaintainCaptureOrder_Enable_Inline(t *testing.T) {
 	}
 	text := "This is a \ntesting stuff"
 	m, err := r.FindStringMatch(text)
-	// t.Errorf(" groups: %#v\n", m)
 	if err != nil {
 		t.Errorf("unexpected match err: %v", err)
 	}
@@ -139,6 +138,35 @@ func TestMaintainCaptureOrder_Enable_Inline(t *testing.T) {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 	if want, got := `last`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_Inline_No_Capture_Groups(t *testing.T) {
+	r, err := Compile("(?o)this.+?testing.+?stuff", 0)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := `this is a testing stuff`
+	m, err := r.FindStringMatch(text)
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := 1, len(groups); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 }

--- a/regexp_MaintainCaptureOrder_test.go
+++ b/regexp_MaintainCaptureOrder_test.go
@@ -34,7 +34,7 @@ func TestMaintainCaptureOrder_Basic(t *testing.T) {
 	if want, got := `first`, groups[1].Name; want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
-	if want, got := `this`, string(m.GroupByName(`first`).Runes()); want != got {
+	if want, got := `this`, m.GroupByName(`first`).String(); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 	if want, got := `first`, m.regex.GroupNameFromNumber(1); want != got {
@@ -52,7 +52,7 @@ func TestMaintainCaptureOrder_Basic(t *testing.T) {
 	if want, got := `last`, groups[3].Name; want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
-	if want, got := `stuff`, string(m.GroupByNumber(3).Runes()); want != got {
+	if want, got := `stuff`, m.GroupByNumber(3).String(); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 }
@@ -87,7 +87,7 @@ func TestMaintainCaptureOrder_Mode_Not_Enabled(t *testing.T) {
 	if want, got := `1`, groups[1].Name; want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
-	if want, got := `this`, string(m.GroupByName(`first`).Runes()); want != got {
+	if want, got := `this`, m.GroupByName(`first`).String(); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 	if want, got := `first`, m.regex.GroupNameFromNumber(2); want != got {
@@ -105,7 +105,7 @@ func TestMaintainCaptureOrder_Mode_Not_Enabled(t *testing.T) {
 	if want, got := `last`, groups[3].Name; want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
-	if want, got := `stuff`, string(m.GroupByNumber(3).Runes()); want != got {
+	if want, got := `stuff`, m.GroupByNumber(3).String(); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 }

--- a/regexp_MaintainCaptureOrder_test.go
+++ b/regexp_MaintainCaptureOrder_test.go
@@ -37,10 +37,66 @@ func TestMaintainCaptureOrder_Basic(t *testing.T) {
 	if want, got := `this`, string(m.GroupByName(`first`).Runes()); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
+	if want, got := `first`, m.regex.GroupNameFromNumber(1); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
 	if want, got := `testing`, groups[2].String(); want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 	if want, got := `2`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `last`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, string(m.GroupByNumber(3).Runes()); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_Mode_Not_Enabled(t *testing.T) {
+	r, err := Compile("(?<first>this).+?(testing).+?(?<last>stuff)", 0)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := `this is a testing stuff`
+	m, err := r.FindStringMatch(text)
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `1`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `this`, string(m.GroupByName(`first`).Runes()); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, m.regex.GroupNameFromNumber(2); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `this`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[2].Name; want != got {
 		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
 	}
 	if want, got := `stuff`, groups[3].String(); want != got {
@@ -98,52 +154,8 @@ func TestMaintainCaptureOrder_With_Other_Options(t *testing.T) {
 	}
 }
 
-func TestMaintainCaptureOrder_Enable_Inline(t *testing.T) {
-	r, err := Compile("(?sio)(?<first>this).+?\n(testing).+?(?<last>stuff)", 0)
-	// t.Logf("code dump: %v", r.code.Dump())
-	if err != nil {
-		t.Errorf("unexpected compile err: %v", err)
-	}
-	text := "This is a \ntesting stuff"
-	m, err := r.FindStringMatch(text)
-	if err != nil {
-		t.Errorf("unexpected match err: %v", err)
-	}
-	if m == nil {
-		t.Error("Nil match, expected success")
-	} else {
-		//t.Logf("Match: %v", m.dump())
-	}
-
-	groups := m.Groups()
-	if want, got := text, m.String(); want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := text, groups[0].String(); want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `This`, groups[1].String(); want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `first`, groups[1].Name; want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `testing`, groups[2].String(); want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `2`, groups[2].Name; want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `stuff`, groups[3].String(); want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-	if want, got := `last`, groups[3].Name; want != got {
-		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
-	}
-}
-
-func TestMaintainCaptureOrder_Inline_No_Capture_Groups(t *testing.T) {
-	r, err := Compile("(?o)this.+?testing.+?stuff", 0)
+func TestMaintainCaptureOrder_No_Capture_Groups(t *testing.T) {
+	r, err := Compile("this.+?testing.+?stuff", MaintainCaptureOrder)
 	// t.Logf("code dump: %v", r.code.Dump())
 	if err != nil {
 		t.Errorf("unexpected compile err: %v", err)

--- a/regexp_MaintainCaptureOrder_test.go
+++ b/regexp_MaintainCaptureOrder_test.go
@@ -1,0 +1,366 @@
+package regexp2
+
+import (
+	"testing"
+)
+
+func TestMaintainCaptureOrder_Basic(t *testing.T) {
+	r, err := Compile("(?<first>this).+?(testing).+?(?<last>stuff)", MaintainCaptureOrder)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := `this is a testing stuff`
+	m, err := r.FindStringMatch(text)
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `this`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `this`, string(m.GroupByName(`first`).Runes()); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `2`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `last`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, string(m.GroupByNumber(3).Runes()); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_With_Other_Options(t *testing.T) {
+	r, err := Compile("(?si)(?<first>this).+?\n(testing).+?(?<last>stuff)", MaintainCaptureOrder)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := "This is a \ntesting stuff"
+	m, err := r.FindStringMatch(text)
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `This`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `2`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `last`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_Enable_Inline(t *testing.T) {
+	r, err := Compile("(?sio)(?<first>this).+?\n(testing).+?(?<last>stuff)", 0)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := "This is a \ntesting stuff"
+	m, err := r.FindStringMatch(text)
+	// t.Errorf(" groups: %#v\n", m)
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `This`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `2`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `last`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_NestedCaptures(t *testing.T) {
+	r, err := Compile(
+		`(?<first>This)(?<second>(.)+?(?<test>testing)).+?(some.+?(other).+?(?<last>stuff)) (?<test>\k<test>)`, MaintainCaptureOrder)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := "This is a testing some other stuff testing"
+	m, err := r.FindStringMatch(text)
+
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `This`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := ` is a testing`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `second`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := groups[2].String(), groups[2].Captures[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := ` `, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `a`, groups[3].Captures[4].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `3`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[4].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `test`, groups[4].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `some other stuff`, groups[5].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `5`, groups[5].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `other`, groups[6].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `6`, groups[6].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[7].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `last`, groups[7].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := 8, len(groups); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_RE2_And_NumBackref(t *testing.T) {
+	r, err := Compile(
+		`(?'first'This).+?(?P<test>testing) (some).+?(?<4>stuff) \2`, MaintainCaptureOrder | RE2)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := "This is a testing some other stuff testing"
+	m, err := r.FindStringMatch(text)
+
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `This`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `first`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `testing`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `test`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `some`, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `3`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `stuff`, groups[4].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `4`, groups[4].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}
+
+func TestMaintainCaptureOrder_Balancing_Conditional_Alternation(t *testing.T) {
+	r, err := Compile(
+		`^[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))$`, MaintainCaptureOrder)
+	// t.Logf("code dump: %v", r.code.Dump())
+	if err != nil {
+		t.Errorf("unexpected compile err: %v", err)
+	}
+	text := "<abc><mno<xyz>>"
+	m, err := r.FindStringMatch(text)
+
+	if err != nil {
+		t.Errorf("unexpected match err: %v", err)
+	}
+	if m == nil {
+		t.Error("Nil match, expected success")
+	} else {
+		//t.Logf("Match: %v", m.dump())
+	}
+
+	groups := m.Groups()
+	if want, got := text, m.String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := text, groups[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<mno<xyz>>`, groups[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<abc>`, groups[1].Captures[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<mno<xyz>>`, groups[1].Captures[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `1`, groups[1].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<xyz`, groups[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<abc`, groups[2].Captures[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<mno`, groups[2].Captures[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `<xyz`, groups[2].Captures[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `2`, groups[2].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := ``, groups[3].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `Open`, groups[3].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `>`, groups[4].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `>`, groups[4].Captures[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `>`, groups[4].Captures[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `>`, groups[4].Captures[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `4`, groups[4].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `mno<xyz>`, groups[5].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `abc`, groups[5].Captures[0].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `xyz`, groups[5].Captures[1].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `mno<xyz>`, groups[5].Captures[2].String(); want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+	if want, got := `Close`, groups[5].Name; want != got {
+		t.Fatalf("Wanted '%v'\nGot '%v'", want, got)
+	}
+}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -22,6 +22,7 @@ const (
 	Debug                                = 0x0080 // "d"
 	ECMAScript                           = 0x0100 // "e"
 	RE2                                  = 0x0200 // RE2 compat mode
+	MaintainCaptureOrder                 = 0x1000 // "o" Maintain named and unnamed capture order
 )
 
 func optionFromCode(ch rune) RegexOptions {
@@ -43,6 +44,8 @@ func optionFromCode(ch rune) RegexOptions {
 		return Debug
 	case 'e', 'E':
 		return ECMAScript
+	case 'o', 'O':
+		return MaintainCaptureOrder
 	default:
 		return 0
 	}
@@ -129,8 +132,9 @@ type parser struct {
 	captop   int
 	capsize  int
 
-	caps     map[int]int
-	capnames map[string]int
+	caps          map[int]int
+	capnames      map[string]int
+	capnamenums   map[string]int
 
 	capnumlist  []int
 	capnamelist []string
@@ -214,6 +218,17 @@ func (p *parser) noteCaptureName(name string, pos int) {
 		p.capnames = make(map[string]int)
 	}
 
+	if p.useMaintainCaptureOrder() {
+		if p.capnamenums == nil {
+			p.capnamenums = make(map[string]int)
+		}
+
+		if _, ok := p.capnamenums[name]; !ok {
+			p.capnamenums[name] = p.autocap
+			p.noteCaptureSlot(p.consumeAutocap(), pos)
+		}
+	}
+
 	if _, ok := p.capnames[name]; !ok {
 		p.capnames[name] = pos
 		p.capnamelist = append(p.capnamelist, name)
@@ -221,73 +236,81 @@ func (p *parser) noteCaptureName(name string, pos int) {
 }
 
 func (p *parser) assignNameSlots() {
-	if p.capnames != nil {
-		for _, name := range p.capnamelist {
-			for p.isCaptureSlot(p.autocap) {
+	if p.useMaintainCaptureOrder() {
+		p.capnames = p.capnamenums
+		// Prepend `0` to capnamelist if it's not set
+		if p.capnamelist[0] != `0` {
+			p.capnamelist = append([]string{fmt.Sprint(0)}, p.capnamelist...)
+		}
+	} else {
+		if p.capnames != nil {
+			for _, name := range p.capnamelist {
+				for p.isCaptureSlot(p.autocap) {
+					p.autocap++
+				}
+				pos := p.capnames[name]
+				p.capnames[name] = p.autocap
+				p.noteCaptureSlot(p.autocap, pos)
+
 				p.autocap++
 			}
-			pos := p.capnames[name]
-			p.capnames[name] = p.autocap
-			p.noteCaptureSlot(p.autocap, pos)
-
-			p.autocap++
 		}
-	}
+		
+		// if the caps array has at least one gap, construct the list of used slots
+		if p.capcount < p.captop {
+			p.capnumlist = make([]int, p.capcount)
+			i := 0
 
-	// if the caps array has at least one gap, construct the list of used slots
-	if p.capcount < p.captop {
-		p.capnumlist = make([]int, p.capcount)
-		i := 0
-
-		for k := range p.caps {
-			p.capnumlist[i] = k
-			i++
-		}
-
-		sort.Ints(p.capnumlist)
-	}
-
-	// merge capsnumlist into capnamelist
-	if p.capnames != nil || p.capnumlist != nil {
-		var oldcapnamelist []string
-		var next int
-		var k int
-
-		if p.capnames == nil {
-			oldcapnamelist = nil
-			p.capnames = make(map[string]int)
-			p.capnamelist = []string{}
-			next = -1
-		} else {
-			oldcapnamelist = p.capnamelist
-			p.capnamelist = []string{}
-			next = p.capnames[oldcapnamelist[0]]
-		}
-
-		for i := 0; i < p.capcount; i++ {
-			j := i
-			if p.capnumlist != nil {
-				j = p.capnumlist[i]
+			for k := range p.caps {
+				p.capnumlist[i] = k
+				i++
 			}
 
-			if next == j {
-				p.capnamelist = append(p.capnamelist, oldcapnamelist[k])
-				k++
+			sort.Ints(p.capnumlist)
+		}
 
-				if k == len(oldcapnamelist) {
-					next = -1
-				} else {
-					next = p.capnames[oldcapnamelist[k]]
+		// merge capsnumlist into capnamelist
+		if p.capnames != nil || p.capnumlist != nil {
+			var oldcapnamelist []string
+			var next int
+			var k int
+
+			if p.capnames == nil {
+				oldcapnamelist = nil
+				p.capnames = make(map[string]int)
+				p.capnamelist = []string{}
+				next = -1
+			} else {
+				oldcapnamelist = p.capnamelist
+				p.capnamelist = []string{}
+				next = p.capnames[oldcapnamelist[0]]
+			}
+
+			for i := 0; i < p.capcount; i++ {
+				j := i
+				if p.capnumlist != nil {
+					j = p.capnumlist[i]
 				}
 
-			} else {
-				//feature: culture?
-				str := strconv.Itoa(j)
-				p.capnamelist = append(p.capnamelist, str)
-				p.capnames[str] = j
+				if next == j {
+					p.capnamelist = append(p.capnamelist, oldcapnamelist[k])
+					k++
+
+					if k == len(oldcapnamelist) {
+						next = -1
+					} else {
+						next = p.capnames[oldcapnamelist[k]]
+					}
+
+				} else {
+					//feature: culture?
+					str := strconv.Itoa(j)
+					p.capnamelist = append(p.capnamelist, str)
+p.capnames[str] = j
+					}
+				}
 			}
 		}
-	}
 }
 
 func (p *parser) consumeAutocap() int {
@@ -301,7 +324,11 @@ func (p *parser) consumeAutocap() int {
 func (p *parser) countCaptures() error {
 	var ch rune
 
-	p.noteCaptureSlot(0, 0)
+	if p.useMaintainCaptureOrder() {
+		p.noteCaptureName(fmt.Sprint(0), 0)
+	} else {
+		p.noteCaptureSlot(0, 0)
+	}
 
 	p.autocap = 1
 
@@ -350,7 +377,11 @@ func (p *parser) countCaptures() error {
 								if err != nil {
 									return err
 								}
-								p.noteCaptureSlot(dec, pos)
+								if p.useMaintainCaptureOrder() {
+									p.noteCaptureName(fmt.Sprint(dec), pos)
+								} else {
+									p.noteCaptureSlot(dec, pos)
+								}
 							} else {
 								p.noteCaptureName(p.scanCapname(), pos)
 							}
@@ -386,7 +417,11 @@ func (p *parser) countCaptures() error {
 					}
 				} else {
 					if !p.useOptionN() && !p.ignoreNextParen {
-						p.noteCaptureSlot(p.consumeAutocap(), pos)
+						if p.useMaintainCaptureOrder() {
+							p.noteCaptureName(fmt.Sprint(p.autocap), pos)
+						} else {
+							p.noteCaptureSlot(p.consumeAutocap(), pos)
+						}
 					}
 				}
 			}
@@ -921,6 +956,10 @@ func (p *parser) scanGroupOpen() (*regexNode, error) {
 					if p.charsRight() > 0 && !(p.rightChar(0) == close || p.rightChar(0) == '-') {
 						return nil, p.getErr(ErrInvalidGroupName)
 					}
+
+					if capnum != -1 && p.useMaintainCaptureOrder() {
+						p.consumeAutocap()
+					}
 				} else if ch == '-' {
 					proceed = true
 				} else {
@@ -1062,6 +1101,9 @@ func (p *parser) scanGroupOpen() (*regexNode, error) {
 					// actually make the node
 
 					if capnum != -1 && p.charsRight() > 0 && p.moveRightGetChar() == '>' {
+						if p.useMaintainCaptureOrder() {
+							p.consumeAutocap()
+						}
 						return newRegexNodeMN(ntCapture, p.options, capnum, -1), nil
 					}
 					goto BreakRecognize
@@ -1966,6 +2008,11 @@ func (p *parser) useOptionE() bool {
 // true to use RE2 compatibility parsing behavior.
 func (p *parser) useRE2() bool {
 	return (p.options & RE2) != 0
+}
+
+// true to use MaintainCaptureOrder parsing behavior.
+func (p *parser) useMaintainCaptureOrder() bool {
+	return (p.options & MaintainCaptureOrder) != 0
 }
 
 // True if options stack is empty.

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -238,8 +238,8 @@ func (p *parser) noteCaptureName(name string, pos int) {
 func (p *parser) assignNameSlots() {
 	if p.useMaintainCaptureOrder() {
 		p.capnames = p.capnamenums
-		// Prepend `0` to capnamelist if it's not set
-		if p.capnamelist[0] != `0` {
+		// Prepend `0` to capnamelist if it's not set (MaintainCaptureOrder was enabled inline)
+		if len(p.capnamelist) == 0 || p.capnamelist[0] != `0` {
 			p.capnamelist = append([]string{fmt.Sprint(0)}, p.capnamelist...)
 		}
 	} else {


### PR DESCRIPTION
In other words maintain the order of capture groups. With the `MaintainCaptureOrder` regexp option.

I also added inline option `o`. It's useful if you only have access to the pattern, but not the regex. But it only is useful if used at the start of the pattern, I couldn't find a way to prevent it from being used elsewhere.

I've never liked nor have been good with bitwise operations. So I don't know if I should've picked another number.