### PR TITLE
Add `MatchStringSafe` Method to Simplify Error Handling in `MatchString`

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -240,6 +240,16 @@ func (re *Regexp) MatchString(s string) (bool, error) {
 	return m != nil, nil
 }
 
+// MatchStringSafe returns true if the string matches the regex.
+// It ignores any errors and simply returns false if an error occurs.
+func (re *Regexp) MatchStringSafe(s string) bool {
+	m, err := re.run(true, -1, getRunes(s))
+	if err != nil {
+		return false
+	}
+	return m != nil
+}
+
 func (re *Regexp) getRunesAndStart(s string, startAt int) ([]rune, int) {
 	if startAt < 0 {
 		if re.RightToLeft() {


### PR DESCRIPTION
#### Description

This PR introduces a new method `MatchStringSafe` to the `Regexp` struct. The new method simplifies the use of regular expressions by returning only a boolean value, ignoring any errors that might occur. This is particularly useful when users are not concerned with specific error handling (e.g., timeout errors) and prefer a simple true/false response.

While the existing `MatchString `method is robust and provides detailed error information, there are many cases where users may not need to handle errors explicitly. In these cases, the additional complexity of dealing with an error value can be cumbersome. The `MatchStringSafe `method simplifies this common use case by allowing users to write more concise and readable code when error handling is not required.