### PR TITLE
fix Incorrect timeout error when using FindStringMatch()

### DIFF
--- a/fastclock.go
+++ b/fastclock.go
@@ -44,21 +44,26 @@ func (t fasttime) reached() bool {
 
 // makeDeadline returns a time that is approximately time.Now().Add(d)
 func makeDeadline(d time.Duration) fasttime {
-	// If time.Since(last use) > timeout, fast.current will no longer be updated,
-	// which can lead to incorrect 'end' calculations resulting in trigger a timeout error
-	// during match
-	if !fast.running && !fast.start.IsZero() {
-		// update fast.current
-		fast.current.write(durationToTicks(time.Since(fast.start)))
-	}
 	// Increase the deadline since the clock we are reading may be
 	// just about to tick forwards.
 	end := fast.current.read() + durationToTicks(d+clockPeriod)
 
 	// Start or extend clock if necessary.
 	if end > fast.clockEnd.read() {
+		// If time.Since(last use) > timeout, there's a chance that
+		// fast.current will no longer be updated, which can lead to
+		// incorrect 'end' calculations that can trigger a false timeout
+		fast.mu.Lock()
+		if !fast.running && !fast.start.IsZero() {
+			// update fast.current
+			fast.current.write(durationToTicks(time.Since(fast.start)))
+			// recalculate our end value
+			end = fast.current.read() + durationToTicks(d+clockPeriod)
+		}
+		fast.mu.Unlock()
 		extendClock(end)
 	}
+
 	return end
 }
 

--- a/fastclock.go
+++ b/fastclock.go
@@ -49,7 +49,7 @@ func makeDeadline(d time.Duration) fasttime {
 	// during match
 	if !fast.running && !fast.start.IsZero() {
 		// update fast.current
-		fast.clockEnd.write(durationToTicks(time.Since(fast.start)))
+		fast.current.write(durationToTicks(time.Since(fast.start)))
 	}
 	// Increase the deadline since the clock we are reading may be
 	// just about to tick forwards.

--- a/fastclock.go
+++ b/fastclock.go
@@ -44,6 +44,13 @@ func (t fasttime) reached() bool {
 
 // makeDeadline returns a time that is approximately time.Now().Add(d)
 func makeDeadline(d time.Duration) fasttime {
+	// If time.Since(last use) > timeout, fast.current will no longer be updated,
+	// which can lead to incorrect 'end' calculations resulting in trigger a timeout error
+	// during match
+	if !fast.running && !fast.start.IsZero() {
+		// update fast.current
+		fast.clockEnd.write(durationToTicks(time.Since(fast.start)))
+	}
 	// Increase the deadline since the clock we are reading may be
 	// just about to tick forwards.
 	end := fast.current.read() + durationToTicks(d+clockPeriod)

--- a/fastclock_test.go
+++ b/fastclock_test.go
@@ -82,3 +82,26 @@ func TestIncorrectDeadline(t *testing.T) {
 		t.Errorf("Expectd deadTick %v, got %v", expectedDeadTick, d)
 	}
 }
+
+func TestIncorrectTimeoutError(t *testing.T) {
+	if fast.start.IsZero() {
+		fast.start = time.Now()
+	}
+	// make fast stopped
+	for fast.running {
+		time.Sleep(clockPeriod)
+	}
+	re := MustCompile(`\[(\d+)\]\s+\[([\s\S]+)\]\s+([\s\S]+).*`, RE2)
+	re.MatchTimeout = 5 * clockPeriod
+
+	// get wrong deadline
+	time.Sleep(10 * clockPeriod)
+
+	// try multi times, if fast.current updated, FindStringMatch will trigger timeout
+	for i := 0; i < 100000; i++ {
+		_, err := re.FindStringMatch("[10000] [Dec 15, 2012 1:42:43 AM] com.dev.log.LoggingExample main")
+		if err != nil {
+			t.Errorf("Expecting error, got nil")
+		}
+	}
+}


### PR DESCRIPTION
fix Timeout Error issue: when the fastclock stop running, then next matches will get a wrong fast.current and daeline, thus trigger an incorrect timeout error.