### PR TITLE
use `sync.Pool` for runner pooling

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -47,8 +47,7 @@ type Regexp struct {
 	code *syntax.Code // compiled program
 
 	// cache of machines for running regexp
-	muRun  *sync.Mutex
-	runner []*runner
+	runner sync.Pool
 }
 
 // Compile parses a regular expression and returns, if successful,
@@ -76,7 +75,11 @@ func Compile(expr string, opt RegexOptions) (*Regexp, error) {
 		capsize:      code.Capsize,
 		code:         code,
 		MatchTimeout: DefaultMatchTimeout,
-		muRun:        &sync.Mutex{},
+		runner: sync.Pool{
+			New: func() interface{} {
+				return new(runner)
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
Currently as noted in the comment of `putRunner`, there's no attempt
being made to limit the size of the runner pooling - this can result in
the pool containing a lot of runners that were once created in a spur
but will likely not be used anymore. Instead of trying to do gc within
this code, move the pooling to `sync.Pool` which will deallocated objects
in idle and therefore keep the size of the pool as small as possible.

The pool is on a per-regexp scope, this means certain properties can be
re-used for optimal performance.

The motivation for this change is that I'm seeing a lot of memory (~300MiB) being
hold by these runners until the Go program is restarted which feels like
an unoptimal usage of memory, with this change after a spur of these
runners have been created in a small amount of time they are gracefully
deallocated over time and no longer hold memory indefinitely.