### PR TITLE
Expose raw/explicit capture group names

### DIFF
--- a/syntax/tree.go
+++ b/syntax/tree.go
@@ -8,13 +8,14 @@ import (
 )
 
 type RegexTree struct {
-	root       *regexNode
-	caps       map[int]int
-	capnumlist []int
-	captop     int
-	Capnames   map[string]int
-	Caplist    []string
-	options    RegexOptions
+	root             *regexNode
+	caps             map[int]int
+	capnumlist       []int
+	captop           int
+	Capnames         map[string]int
+	explicitcapnames []string
+	Caplist          []string
+	options          RegexOptions
 }
 
 // It is built into a parsed tree for a regular expression.
@@ -614,6 +615,12 @@ func (n *regexNode) description() string {
 }
 
 var padSpace = []byte("                                ")
+
+func (t *RegexTree) GetExplicitlyNamedCaptureGroups() []string {
+	result := make([]string, len(t.explicitcapnames))
+	copy(result, t.explicitcapnames)
+	return result
+}
 
 func (t *RegexTree) Dump() string {
 	return t.root.dump()


### PR DESCRIPTION
Context: https://github.com/dlclark/regexp2/issues/94.

I've made the following changes:
- In parser.go, we now record the names of the capture groups as they appeared literally in the regexp. This is done even if a group was named after an integer, e.g. "3".
- In regexp.go, we expose this information via GetRawGroupNames().

Example code:
```go
package main

import (
	"github.com/dlclark/regexp2"
)

func main() {
	pattern := `(abc) (?<2>def) (?<X>foo) (?#somecomment) (bar) (?<middle>f) (?>abc) (?=abc) (?<last>abc)`
	println("Pattern:", pattern)
	r := regexp2.MustCompile(pattern, regexp2.ECMAScript)

	println("group names:")
	for _, name := range r.GetGroupNames() {
		println(name)
	}

	println("----")
	println("raw group names:")

	for _, n := range r.GetRawGroupNames() {
		println(n)
	}

	println("----")
	println("group numbers:")

	for _, n := range r.GetGroupNumbers() {
		println(n)
	}
}
```

Output:
```
Pattern: (abc) (?<2>def) (?<X>foo) (?#somecomment) (bar) (?<middle>f) (?>abc) (?=abc) (?<last>abc)
group names:
0
1
2
X
middle
last
----
raw group names:
2
X
middle
last
----
group numbers:
0
1
2
3
4
5
```

Would an approach like this make sense? Maybe "raw group names" is not the correct term to use here, I could change it. What I currently dislike about this approach is that GetRawGroupNames() does not return a slice of the same length as GetGroupNames(), plus the groups do not appear in the same order as well (due to how `assignNameSlots()` can modify the slice of names stored in `capnamelist`).
I can add comments and unit tests if we agree on the overall design.

Edit: alternative names could be:
- "explicitly named groups"
- "directly named groups"
- "literal named groups"