### PR TITLE
Proposal: support Go official versions 1.25 and 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dlclark/regexp2/v2
 
-go 1.26
+go 1.25


### PR DESCRIPTION
Go offiically supports two stable versions, and quite a few upstream packages (including Hugo) still support Go 1.25.