### PR TITLE
Add failing test for negative digit ignore case

### DIFF
--- a/regexp_test.go
+++ b/regexp_test.go
@@ -538,6 +538,17 @@ func TestRunNegativeDigit(t *testing.T) {
 	}
 }
 
+func TestRunNegativeDigitIgnoreCaseRE2(t *testing.T) {
+	re := MustCompile(`\D`, IgnoreCase|RE2)
+	m, err := re.MatchString("test")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !m {
+		t.Fatalf("Expected match")
+	}
+}
+
 func TestCancellingClasses(t *testing.T) {
 	// [\w\W\s] should become "." because it means "anything"
 	re := MustCompile(`[\w\W\s]`)


### PR DESCRIPTION
It seems like `canonicalize` is broken for `\D` when `IgnoreCase|RE2` is specified for the compile options.